### PR TITLE
(maint) Bump ruby version to 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.0.0"
+ruby "2.3.1"
 
 gem "json"
 gem "sinatra"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
-      builder (~> 3.1)
-    activesupport (4.2.6)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    builder (3.2.2)
-    domain_name (0.5.20160310)
+    concurrent-ruby (1.0.2)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    json (1.8.3)
+    json (2.0.2)
     mime-types (2.99.2)
     minitest (5.9.0)
     netrc (0.11.0)
-    oauth (0.4.7)
+    oauth (0.5.1)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -29,11 +27,11 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    ruby-trello (1.4.2)
+    ruby-trello (1.5.1)
       activemodel (>= 3.2.0)
       addressable (~> 2.3)
       json
-      oauth (~> 0.4.5)
+      oauth (>= 0.4.5)
       rest-client (~> 1.8.0)
     sinatra (1.4.7)
       rack (~> 1.5)
@@ -55,5 +53,8 @@ DEPENDENCIES
   ruby-trello
   sinatra
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
This commit updates the ruby verion to 2.3.1 up from the very
out of date 2.0.0. Also bumps the gem versions in the lockfile.
